### PR TITLE
Recommendation to remove italic styling

### DIFF
--- a/app/src/main/res/layout/activity_find_replace.xml
+++ b/app/src/main/res/layout/activity_find_replace.xml
@@ -49,7 +49,7 @@
             android:layout_marginStart="10dp"
             android:textColor="@color/blue"
             android:layout_gravity="center"
-            android:textStyle="bold|italic" />
+            android:textStyle="bold" />
 
         <androidx.appcompat.widget.AppCompatEditText
             android:id="@+id/from_text"
@@ -72,7 +72,7 @@
             android:layout_marginStart="10dp"
             android:textColor="@color/blue"
             android:layout_gravity="center"
-            android:textStyle="bold|italic" />
+            android:textStyle="bold" />
 
         <androidx.appcompat.widget.AppCompatEditText
             android:id="@+id/to_text"

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -70,7 +70,6 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:textColor="?android:attr/textColorPrimary"
-                android:textStyle="italic"
                 android:clickable="false" />
         </LinearLayout>
     </LinearLayout>

--- a/app/src/main/res/layout/fragment_translator.xml
+++ b/app/src/main/res/layout/fragment_translator.xml
@@ -98,7 +98,6 @@
                 android:layout_height="wrap_content"
                 android:text="@string/import_string_message"
                 android:textColor="@color/blue"
-                android:textStyle="italic"
                 android:focusable="false"
                 android:textSize="17sp" />
         </androidx.appcompat.widget.LinearLayoutCompat>

--- a/app/src/main/res/layout/layout_string_edit.xml
+++ b/app/src/main/res/layout/layout_string_edit.xml
@@ -20,7 +20,7 @@
             android:hint="@string/add_text_hint"
             android:layout_marginStart="15dp"
             android:textColor="@color/blue"
-            android:textStyle="italic|bold"
+            android:textStyle="bold"
             android:layout_gravity="center"
             android:layout_marginEnd="30dp"
             android:background="@null"

--- a/app/src/main/res/layout/recycle_view_settings.xml
+++ b/app/src/main/res/layout/recycle_view_settings.xml
@@ -32,7 +32,6 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:textColor="?android:attr/textColorPrimary"
-                    android:textStyle="italic"
                     android:visibility="gone" />
         </LinearLayout>
 </LinearLayout>


### PR DESCRIPTION
Not every language has a writing system which is easily legible in Italics, so it would be appropriate to avoid using them in this app. For right-to-left scripts, it causes the beginning of lines to be clipped off (see image).
![Screenshot_20221031-015850](https://user-images.githubusercontent.com/100172442/198942700-fd3fbe20-221f-4cfd-a4cb-bcd1be71c701.png)
